### PR TITLE
[26845] Link to two-factor authentication not working

### DIFF
--- a/lib/open_project/two_factor_authentication/patches/users_helper_patch.rb
+++ b/lib/open_project/two_factor_authentication/patches/users_helper_patch.rb
@@ -13,7 +13,11 @@ module OpenProject::TwoFactorAuthentication::Patches
       # Adds a 2FA tab to the user administration page
       def user_settings_tabs_with_2fa
         # Core defined data
-        user_settings_tabs_without_2fa + [{ name: 'two_factor_authentication', partial: 'users/two_factor_authentication', label: 'two_factor_authentication.label_two_factor_authentication' }]
+        if OpenProject::TwoFactorAuthentication::TokenStrategyManager.enabled?
+          user_settings_tabs_without_2fa + [{ name: 'two_factor_authentication', partial: 'users/two_factor_authentication', label: 'two_factor_authentication.label_two_factor_authentication' }]
+        else
+          user_settings_tabs_without_2fa
+        end
       end
     end
   end


### PR DESCRIPTION
Show 2fa tab in Admin/users only when it is enabled. Since it was shown the link directed to a non existent page.

https://community.openproject.com/projects/openproject/work_packages/26845/activity